### PR TITLE
Accept Python builtins for basic operations

### DIFF
--- a/classad/_primitives.py
+++ b/classad/_primitives.py
@@ -225,7 +225,7 @@ class HTCInt(int, PrimitiveExpression):
             return HTCBool(super().__ne__(other))
         elif isinstance(other, float):
             return NotImplemented
-        return HTCBool(False)
+        return HTCBool(True)
 
     def __htc_not__(self) -> "Union[HTCBool, Undefined, Error]":
         return Error()

--- a/classad/_primitives.py
+++ b/classad/_primitives.py
@@ -116,11 +116,7 @@ class HTCInt(int, PrimitiveExpression):
     def __add__(self, other):
         if isinstance(other, int):
             return HTCInt(super().__add__(other))
-        elif (
-            isinstance(other, float)
-            or isinstance(other, Undefined)
-            or isinstance(other, Error)
-        ):
+        elif isinstance(other, (float, Undefined, Error)):
             return NotImplemented
         return Error()
 
@@ -129,22 +125,14 @@ class HTCInt(int, PrimitiveExpression):
     def __sub__(self, other):
         if isinstance(other, int):
             return HTCInt(super().__sub__(other))
-        elif (
-            isinstance(other, float)
-            or isinstance(other, Undefined)
-            or isinstance(other, Error)
-        ):
+        elif isinstance(other, (float, Undefined, Error)):
             return NotImplemented
         return Error()
 
     def __mul__(self, other):
         if isinstance(other, int):
             return HTCInt(super().__mul__(other))
-        elif (
-            isinstance(other, float)
-            or isinstance(other, Undefined)
-            or isinstance(other, Error)
-        ):
+        elif isinstance(other, (float, Undefined, Error)):
             return NotImplemented
         return Error()
 
@@ -152,11 +140,7 @@ class HTCInt(int, PrimitiveExpression):
         try:
             if isinstance(other, int):
                 return HTCFloat(super().__truediv__(other))
-            elif (
-                isinstance(other, float)
-                or isinstance(other, Undefined)
-                or isinstance(other, Error)
-            ):
+            elif isinstance(other, (float, Undefined, Error)):
                 return NotImplemented
             return Error()
         except ZeroDivisionError:
@@ -279,7 +263,7 @@ class HTCFloat(float, PrimitiveExpression):
     def __mul__(self, other):
         if isinstance(other, (int, float)):
             return HTCFloat(super().__mul__(other))
-        elif isinstance(other, (int, float)):
+        elif isinstance(other, (Undefined, Error)):
             return NotImplemented
         return Error()
 
@@ -293,7 +277,7 @@ class HTCFloat(float, PrimitiveExpression):
     ) -> Union[PrimitiveExpression, Undefined, Error]:
         if isinstance(other, (int, float)):
             return HTCBool(super().__eq__(other))
-        elif isinstance(other, Undefined) or isinstance(other, Error):
+        elif isinstance(other, (Undefined, Error)):
             return NotImplemented
         return Error()
 
@@ -344,7 +328,7 @@ class HTCBool(PrimitiveExpression):
 
     def __or__(self, other):
         if not self._value:
-            if isinstance(other, HTCBool) or isinstance(other, Undefined):
+            if isinstance(other, (HTCBool, Undefined)):
                 return other
         elif self._value:
             return HTCBool(True)
@@ -354,7 +338,7 @@ class HTCBool(PrimitiveExpression):
         if not self._value:
             return HTCBool(False)
         elif self._value:
-            if isinstance(other, HTCBool) or isinstance(other, Undefined):
+            if isinstance(other, (HTCBool, Undefined)):
                 return other
         return Error()
 
@@ -363,7 +347,7 @@ class HTCBool(PrimitiveExpression):
     ) -> Union[PrimitiveExpression, Undefined, Error]:
         if isinstance(other, HTCBool):
             return HTCBool(self._value is other._value)
-        elif isinstance(other, Undefined) or isinstance(other, Error):
+        elif isinstance(other, (Undefined, Error)):
             return NotImplemented
         elif isinstance(other, bool):
             return HTCBool(self._value is other)

--- a/classad/_primitives.py
+++ b/classad/_primitives.py
@@ -324,8 +324,20 @@ class HTCBool(PrimitiveExpression):
         super().__init__()
         self._value = True if x != 0 else False
 
+    def __add__(self, other):
+        return Error()
+
+    __sub__ = __mul__ = __truediv__ = __gt__ = __ge__ = __le__ = __lt__ = __add__
+
     def __eq__(self, other):
-        return type(self) == type(other) and self._value == other._value
+        return (
+            type(self) == type(other) and self._value == other._value
+        ) or other is self._value
+
+    def __ne__(self, other):
+        return (
+            type(self) == type(other) and self._value != other._value
+        ) or other is not self._value
 
     def __bool__(self):
         return self._value
@@ -345,6 +357,22 @@ class HTCBool(PrimitiveExpression):
             if isinstance(other, HTCBool) or isinstance(other, Undefined):
                 return other
         return Error()
+
+    def __htc_eq__(
+        self, other: PrimitiveExpression
+    ) -> Union[PrimitiveExpression, Undefined, Error]:
+        if isinstance(other, HTCBool):
+            return HTCBool(self._value is other._value)
+        elif isinstance(other, Undefined) or isinstance(other, Error):
+            return NotImplemented
+        elif isinstance(other, bool):
+            return HTCBool(self._value is other)
+        return Error()
+
+    def __htc_ne__(
+        self, other: "PrimitiveExpression"
+    ) -> "Union[HTCBool, Undefined, Error]":
+        return self.__htc_not__().__htc_eq__(other)
 
     def __htc_not__(self) -> "Union[HTCBool, Undefined, Error]":
         return HTCBool(not self._value)

--- a/classad/_primitives.py
+++ b/classad/_primitives.py
@@ -114,21 +114,23 @@ class Error(PrimitiveExpression):
 
 class HTCInt(int, PrimitiveExpression):
     def __add__(self, other):
-        if isinstance(other, HTCInt):
+        if isinstance(other, int):
             return HTCInt(super().__add__(other))
         elif (
-            isinstance(other, HTCFloat)
+            isinstance(other, float)
             or isinstance(other, Undefined)
             or isinstance(other, Error)
         ):
             return NotImplemented
         return Error()
 
+    __radd__ = __add__
+
     def __sub__(self, other):
-        if isinstance(other, HTCInt):
+        if isinstance(other, int):
             return HTCInt(super().__sub__(other))
         elif (
-            isinstance(other, HTCFloat)
+            isinstance(other, float)
             or isinstance(other, Undefined)
             or isinstance(other, Error)
         ):
@@ -136,10 +138,10 @@ class HTCInt(int, PrimitiveExpression):
         return Error()
 
     def __mul__(self, other):
-        if isinstance(other, HTCInt):
+        if isinstance(other, int):
             return HTCInt(super().__mul__(other))
         elif (
-            isinstance(other, HTCFloat)
+            isinstance(other, float)
             or isinstance(other, Undefined)
             or isinstance(other, Error)
         ):
@@ -148,10 +150,10 @@ class HTCInt(int, PrimitiveExpression):
 
     def __truediv__(self, other):
         try:
-            if isinstance(other, HTCInt):
+            if isinstance(other, int):
                 return HTCFloat(super().__truediv__(other))
             elif (
-                isinstance(other, HTCFloat)
+                isinstance(other, float)
                 or isinstance(other, Undefined)
                 or isinstance(other, Error)
             ):
@@ -162,35 +164,45 @@ class HTCInt(int, PrimitiveExpression):
 
     def __lt__(self, other):
         try:
-            return HTCBool(super().__lt__(other))
+            result = super().__lt__(other)
         except TypeError:
             return Error()
+        else:
+            return result if result is NotImplemented else HTCBool(result)
 
     def __ge__(self, other):
-        result = self.__lt__(other)
-        if isinstance(result, HTCBool):
-            return HTCBool(not result)
-        return result
+        try:
+            result = super().__ge__(other)
+        except TypeError:
+            return Error()
+        else:
+            return result if result is NotImplemented else HTCBool(result)
 
     def __gt__(self, other):
         try:
-            return HTCBool(super().__gt__(other))
+            result = super().__gt__(other)
         except TypeError:
             return Error()
+        else:
+            return result if result is NotImplemented else HTCBool(result)
 
     def __le__(self, other):
-        result = self.__gt__(other)
-        if isinstance(result, HTCBool):
-            return HTCBool(not result)
-        return result
+        try:
+            result = super().__le__(other)
+        except TypeError:
+            return Error()
+        else:
+            return result if result is NotImplemented else HTCBool(result)
 
     def __htc_eq__(
         self, other: PrimitiveExpression
     ) -> Union[PrimitiveExpression, Undefined, Error]:
-        if type(self) == type(other) or isinstance(other, HTCFloat):
+        if isinstance(other, int):
             return HTCBool(super().__eq__(other))
-        elif isinstance(other, Undefined) or isinstance(other, Error):
+        elif isinstance(other, (Undefined, Error, HTCFloat)):
             return NotImplemented
+        elif isinstance(other, float):
+            return HTCBool(self == other)
         return Error()
 
     def __htc_ne__(
@@ -202,13 +214,17 @@ class HTCInt(int, PrimitiveExpression):
         return result
 
     def __eq__(self, other: PrimitiveExpression) -> "HTCBool":
-        if type(self) == type(other) and super().__eq__(other):
-            return HTCBool(True)
+        if isinstance(other, int):
+            return HTCBool(super().__eq__(other))
+        elif isinstance(other, float):
+            return NotImplemented
         return HTCBool(False)
 
     def __ne__(self, other: PrimitiveExpression) -> "HTCBool":
-        if type(self) != type(other) or super().__ne__(other):
-            return HTCBool(True)
+        if isinstance(other, int):
+            return HTCBool(super().__ne__(other))
+        elif isinstance(other, float):
+            return NotImplemented
         return HTCBool(False)
 
     def __htc_not__(self) -> "Union[HTCBool, Undefined, Error]":
@@ -261,9 +277,9 @@ class HTCStr(str, PrimitiveExpression):
 
 class HTCFloat(float, PrimitiveExpression):
     def __mul__(self, other):
-        if isinstance(other, HTCFloat) or isinstance(other, HTCInt):
+        if isinstance(other, (int, float)):
             return HTCFloat(super().__mul__(other))
-        elif isinstance(other, Undefined) or isinstance(other, Error):
+        elif isinstance(other, (int, float)):
             return NotImplemented
         return Error()
 
@@ -271,6 +287,33 @@ class HTCFloat(float, PrimitiveExpression):
 
     def __htc_not__(self) -> "Union[HTCBool, Undefined, Error]":
         return Error()
+
+    def __htc_eq__(
+        self, other: PrimitiveExpression
+    ) -> Union[PrimitiveExpression, Undefined, Error]:
+        if isinstance(other, (int, float)):
+            return HTCBool(super().__eq__(other))
+        elif isinstance(other, Undefined) or isinstance(other, Error):
+            return NotImplemented
+        return Error()
+
+    def __htc_ne__(
+        self, other: PrimitiveExpression
+    ) -> Union[PrimitiveExpression, Undefined, Error]:
+        result = self.__htc_eq__(other)
+        if isinstance(result, HTCBool):
+            return HTCBool(not result)
+        return result
+
+    def __eq__(self, other: PrimitiveExpression) -> "HTCBool":
+        if isinstance(other, (int, float)):
+            return HTCBool(super().__eq__(other))
+        return HTCBool(False)
+
+    def __ne__(self, other: PrimitiveExpression) -> "HTCBool":
+        if isinstance(other, (int, float)):
+            return HTCBool(super().__ne__(other))
+        return HTCBool(False)
 
     def __repr__(self):
         return f"<{self.__class__.__name__}>: {self}"

--- a/classad_tests/test_builtins.py
+++ b/classad_tests/test_builtins.py
@@ -1,0 +1,62 @@
+import operator
+
+import pytest
+
+from classad._primitives import (
+    Error,
+    Undefined,
+    HTCInt,
+    HTCFloat,
+    # HTCList,
+    # HTCStr,
+    HTCBool,
+)
+from classad._operator import eq_operator, ne_operator
+
+
+NUMERIC_OPERATORS = (
+    operator.__add__,
+    operator.__sub__,
+    operator.__mul__,
+    operator.__truediv__,
+)
+COMPARISON_OPERATORS = (
+    operator.__eq__,
+    operator.__ne__,
+    operator.__gt__,
+    operator.__ge__,
+    operator.__le__,
+    operator.__lt__,
+    eq_operator,
+    ne_operator,
+)
+
+
+@pytest.fixture(params=[HTCInt, HTCFloat])
+def num_type(request):
+    return request.param
+
+
+def test_numbers(num_type):
+    def assert_similar(op, htc_value, htc_type, builtin_value):
+        """An HTC and builtin type behave similar with respect to an HTC value"""
+        assert op(htc_value, htc_type(builtin_value)) == op(
+            htc_value, htc_type(builtin_value)
+        )
+        assert op(htc_value, htc_type(builtin_value)) == op(htc_value, builtin_value)
+
+    for value in (2, 3, -3, 256, -127, 2 ** 8, 1e6) + (
+            () if num_type is HTCInt else (3-5, -3.5, 127.3, -123.2, 1e-8)
+    ):
+        for operation in NUMERIC_OPERATORS + COMPARISON_OPERATORS:
+            assert_similar(operation, HTCInt(1), num_type, value)
+            assert_similar(operation, HTCInt(123), num_type, value)
+            assert_similar(operation, HTCInt(-123), num_type, value)
+            assert_similar(operation, HTCFloat(1), num_type, value)
+            assert_similar(operation, HTCFloat(123), num_type, value)
+            assert_similar(operation, HTCFloat(-123), num_type, value)
+        for operation in COMPARISON_OPERATORS:
+            assert_similar(operation, HTCBool(True), num_type, value)
+            assert_similar(operation, HTCBool(False), num_type, value)
+            assert_similar(operation, Error(), num_type, value)
+            assert_similar(operation, Undefined(), num_type, value)

--- a/classad_tests/test_builtins.py
+++ b/classad_tests/test_builtins.py
@@ -46,7 +46,7 @@ def test_numbers(num_type):
         assert op(htc_value, htc_type(builtin_value)) == op(htc_value, builtin_value)
 
     for value in (2, 3, -3, 256, -127, 2 ** 8, 1e6) + (
-            () if num_type is HTCInt else (3-5, -3.5, 127.3, -123.2, 1e-8)
+        () if num_type is HTCInt else (3 - 5, -3.5, 127.3, -123.2, 1e-8)
     ):
         for operation in NUMERIC_OPERATORS + COMPARISON_OPERATORS:
             assert_similar(operation, HTCInt(1), num_type, value)


### PR DESCRIPTION
This PR allows using Python int/float builtins in some operations. Changes include:

* [x] most ``HTC`` types accept ``int`` and ``float`` as right-hand-side operators,
* [x] added some additional operators for ``HTCBool`` and ``HTFloat``. 