### PR TITLE
Lookup mechanism for classads if attribute is not in local but target 

### DIFF
--- a/classad_tests/test_matchmaking.py
+++ b/classad_tests/test_matchmaking.py
@@ -1,5 +1,5 @@
 from classad import parse
-from classad._primitives import HTCInt
+from classad._primitives import HTCInt, Undefined
 
 
 def test_simple():
@@ -17,6 +17,32 @@ def test_simple():
 
 def test_nested():
     my_classad = parse("""rank = TARGET.a.b + TARGET.c""")
+    target_classad = parse("""[c = 1; a = [b = 2; d = 1]]""")
+    assert my_classad.evaluate(
+        key="rank", my=my_classad, target=target_classad
+    ) == HTCInt(3)
+
+
+def test_undefined():
+    assert parse("""rank = TARGET.a""").evaluate("rank") == Undefined()
+    assert parse("""rank = my.a""").evaluate("rank") == Undefined()
+
+
+def test_lookup():
+    my_classad = parse(
+        """
+    a = 10
+    b = c
+    """
+    )
+    target_classad = parse("""c = 1""")
+    assert my_classad.evaluate(key="b", my=my_classad, target=target_classad) == HTCInt(
+        1
+    )
+
+
+def test_nested_lookup():
+    my_classad = parse("""rank = a.b + c""")
     target_classad = parse("""[c = 1; a = [b = 2; d = 1]]""")
     assert my_classad.evaluate(
         key="rank", my=my_classad, target=target_classad

--- a/docs/source/change/13.attribute_lookup.yaml
+++ b/docs/source/change/13.attribute_lookup.yaml
@@ -1,0 +1,8 @@
+category: changed
+summary: "Lookup mechanism of attributes"
+description: |
+  The lookup mechanism for attributes now also considers the target classad if
+  an attribute cannot be found in the local context. However, this is valid
+  only for attributes that are neither referencing ``my`` nor ``target``.
+pull requests:
+  - 13


### PR DESCRIPTION
For old classads the mechanism is that if an attribute cannot be found in the local classad, that the target classad is checked. However, we must still check if this is also correct for new classads.
This PR includes:

* [x] unit test,
* [x] change fragment.