### PR TITLE
Expression base type and Slots

### DIFF
--- a/classad/_base_expression.py
+++ b/classad/_base_expression.py
@@ -1,23 +1,47 @@
 import pyparsing as pp
 
-from typing import Iterable, Any, TYPE_CHECKING, Union, Optional
+from typing import Iterable, Any, TYPE_CHECKING, Union, Optional, Tuple
 
 if TYPE_CHECKING:
     from ._expression import ClassAd
     from ._primitives import Undefined, Error, HTCBool
 
 
-class CompoundExpression:
+class Expression:
     __slots__ = ()
-
-    _expression: "CompoundExpression"
 
     def evaluate(
         self,
         key: "Optional[Iterable[Union[str, CompoundExpression]]]" = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
-    ) -> Any:
+    ) -> "Expression":
+        raise NotImplementedError
+
+    def _evaluate(
+        self,
+        key: "Optional[Iterable[Union[str, CompoundExpression]]]" = None,
+        my: "Optional[ClassAd]" = None,
+        target: "Optional[ClassAd]" = None,
+    ) -> "Expression":
+        raise NotImplementedError
+
+    @classmethod
+    def from_grammar(cls, tokens):
+        raise NotImplementedError
+
+
+class CompoundExpression(Expression):
+    __slots__ = '_expression'
+
+    _expression: Tuple[Expression, ...]
+
+    def evaluate(
+        self,
+        key: "Optional[Iterable[Union[str, CompoundExpression]]]" = None,
+        my: "Optional[ClassAd]" = None,
+        target: "Optional[ClassAd]" = None,
+    ) -> "Expression":
         if isinstance(key, str):
             key = key.split(".")
         return self._evaluate(key=key, my=my, target=target)
@@ -54,7 +78,7 @@ class CompoundExpression:
         return type(self) == type(other) and self._expression == other._expression
 
 
-class PrimitiveExpression(CompoundExpression):
+class PrimitiveExpression(Expression):
     __slots__ = ()
 
     def evaluate(
@@ -62,7 +86,7 @@ class PrimitiveExpression(CompoundExpression):
         key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
-    ) -> Any:
+    ) -> "Expression":
         return self
 
     def _evaluate(
@@ -70,7 +94,7 @@ class PrimitiveExpression(CompoundExpression):
         key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
-    ) -> Any:
+    ) -> "Expression":
         return self
 
     def __htc_eq__(

--- a/classad/_base_expression.py
+++ b/classad/_base_expression.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
 
 
 class Expression:
+    __slots__ = ()
+
     _expression: "Expression"
 
     def evaluate(
@@ -53,6 +55,8 @@ class Expression:
 
 
 class PrimitiveExpression(Expression):
+    __slots__ = ()
+
     def evaluate(
         self,
         key: Optional[Iterable[Union[str, Expression]]] = None,

--- a/classad/_base_expression.py
+++ b/classad/_base_expression.py
@@ -7,14 +7,14 @@ if TYPE_CHECKING:
     from ._primitives import Undefined, Error, HTCBool
 
 
-class Expression:
+class CompoundExpression:
     __slots__ = ()
 
-    _expression: "Expression"
+    _expression: "CompoundExpression"
 
     def evaluate(
         self,
-        key: "Optional[Iterable[Union[str, Expression]]]" = None,
+        key: "Optional[Iterable[Union[str, CompoundExpression]]]" = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:
@@ -24,7 +24,7 @@ class Expression:
 
     def _evaluate(
         self,
-        key: "Optional[Iterable[Union[str, Expression]]]" = None,
+        key: "Optional[Iterable[Union[str, CompoundExpression]]]" = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:
@@ -54,12 +54,12 @@ class Expression:
         return type(self) == type(other) and self._expression == other._expression
 
 
-class PrimitiveExpression(Expression):
+class PrimitiveExpression(CompoundExpression):
     __slots__ = ()
 
     def evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:
@@ -67,7 +67,7 @@ class PrimitiveExpression(Expression):
 
     def _evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:

--- a/classad/_base_expression.py
+++ b/classad/_base_expression.py
@@ -32,7 +32,7 @@ class Expression:
 
 
 class CompoundExpression(Expression):
-    __slots__ = '_expression'
+    __slots__ = "_expression"
 
     _expression: Tuple[Expression, ...]
 

--- a/classad/_expression.py
+++ b/classad/_expression.py
@@ -2,7 +2,7 @@ import operator
 from collections import MutableMapping
 
 import pyparsing as pp
-from typing import Any, Iterable, List, Iterator, Optional, Union, Tuple
+from typing import Iterable, List, Iterator, Optional, Union, Tuple
 
 from classad._operator import eq_operator, ne_operator, not_operator
 from classad._primitives import Error, Undefined, HTCBool

--- a/classad/_expression.py
+++ b/classad/_expression.py
@@ -26,7 +26,9 @@ class ClassAd(CompoundExpression, MutableMapping):
         super().__init__()
         self._data = dict()
 
-    def __setitem__(self, key: Union[str, CompoundExpression], value: Expression) -> None:
+    def __setitem__(
+        self, key: Union[str, CompoundExpression], value: Expression
+    ) -> None:
         """
         Keynames that are reserved and, therefore, cannot be used: error, false, is,
             isnt, parent, true, undefined
@@ -103,7 +105,7 @@ class NamedExpression(CompoundExpression):
 
 
 class FunctionExpression(CompoundExpression):
-    __slots__ = '_name',
+    __slots__ = ("_name",)
 
     def __init__(self, name: str, args: Tuple[Expression, ...]):
         super().__init__()

--- a/classad/_expression.py
+++ b/classad/_expression.py
@@ -91,6 +91,8 @@ class ClassAd(Expression, MutableMapping):
 
 
 class NamedExpression(Expression):
+    __slots__ = '_expression',
+
     @classmethod
     def from_grammar(cls, tokens):
         if "super" == tokens:
@@ -101,6 +103,8 @@ class NamedExpression(Expression):
 
 
 class FunctionExpression(Expression):
+    __slots__ = '_expression', '_name'
+
     def __init__(self, name, args):
         super().__init__()
         self._name = name
@@ -133,6 +137,8 @@ class FunctionExpression(Expression):
 
 
 class TernaryExpression(Expression):
+    __slots__ = '_expression',
+
     def _evaluate(
         self,
         key: Optional[Iterable[Union[str, Expression]]] = None,
@@ -157,6 +163,8 @@ class TernaryExpression(Expression):
 
 
 class DotExpression(Expression):
+    __slots__ = '_expression',
+
     def _evaluate(
         self,
         key: Optional[Iterable[Union[str, Expression]]] = None,
@@ -188,6 +196,8 @@ class DotExpression(Expression):
 
 
 class SubscriptableExpression(Expression):
+    __slots__ = '_expression',
+
     def _evaluate(
         self,
         key: Optional[Iterable[Union[str, Expression]]] = None,
@@ -200,6 +210,8 @@ class SubscriptableExpression(Expression):
 
 
 class AttributeExpression(Expression):
+    __slots__ = '_expression',
+
     def _evaluate(
         self,
         key: Optional[Iterable[Union[str, Expression]]] = None,
@@ -260,6 +272,8 @@ class AttributeExpression(Expression):
 
 
 class UnaryExpression(Expression):
+    __slots__ = '_expression',
+
     operator_map = {"-": None, "!": not_operator}
 
     def _evaluate(
@@ -273,6 +287,8 @@ class UnaryExpression(Expression):
 
 
 class ArithmeticExpression(Expression):
+    __slots__ = '_expression',
+
     operator_map = {
         "+": operator.add,
         "-": operator.sub,

--- a/classad/_expression.py
+++ b/classad/_expression.py
@@ -6,7 +6,7 @@ from typing import Any, Iterable, List, Iterator, Optional, Union
 
 from classad._operator import eq_operator, ne_operator, not_operator
 from classad._primitives import Error, Undefined, HTCBool
-from ._base_expression import Expression
+from ._base_expression import CompoundExpression
 from . import _functions
 
 
@@ -14,7 +14,7 @@ def scope_up(key: List[str]):
     return key[:-1]
 
 
-class ClassAd(Expression, MutableMapping):
+class ClassAd(CompoundExpression, MutableMapping):
     __slots__ = "_data"
 
     def __add__(self, other):
@@ -26,7 +26,7 @@ class ClassAd(Expression, MutableMapping):
         super().__init__()
         self._data = dict()
 
-    def __setitem__(self, key: Union[str, Expression], value: Expression) -> None:
+    def __setitem__(self, key: Union[str, CompoundExpression], value: CompoundExpression) -> None:
         """
         Keynames that are reserved and, therefore, cannot be used: error, false, is,
             isnt, parent, true, undefined
@@ -39,10 +39,10 @@ class ClassAd(Expression, MutableMapping):
             raise ValueError(f"{key} is a reserved name")
         self._data[key] = value
 
-    def __delitem__(self, key: Union[str, Expression]) -> None:
+    def __delitem__(self, key: Union[str, CompoundExpression]) -> None:
         self._data.pop(key, None)
 
-    def __getitem__(self, key: Iterable[Union[str, Expression]]) -> Expression:
+    def __getitem__(self, key: Iterable[Union[str, CompoundExpression]]) -> CompoundExpression:
         if isinstance(key, str):
             key = [key]
         expression = self._data
@@ -62,7 +62,7 @@ class ClassAd(Expression, MutableMapping):
 
     def _evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:
@@ -90,7 +90,7 @@ class ClassAd(Expression, MutableMapping):
         return f"<{self.__class__.__name__}>: {self._data}"
 
 
-class NamedExpression(Expression):
+class NamedExpression(CompoundExpression):
     __slots__ = '_expression',
 
     @classmethod
@@ -102,7 +102,7 @@ class NamedExpression(Expression):
         return result
 
 
-class FunctionExpression(Expression):
+class FunctionExpression(CompoundExpression):
     __slots__ = '_expression', '_name'
 
     def __init__(self, name, args):
@@ -119,7 +119,7 @@ class FunctionExpression(Expression):
 
     def _evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:
@@ -136,12 +136,12 @@ class FunctionExpression(Expression):
         return f"<{self.__class__.__name__}>: {self._name}{self._expression}"
 
 
-class TernaryExpression(Expression):
+class TernaryExpression(CompoundExpression):
     __slots__ = '_expression',
 
     def _evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:
@@ -162,12 +162,12 @@ class TernaryExpression(Expression):
         return Error()
 
 
-class DotExpression(Expression):
+class DotExpression(CompoundExpression):
     __slots__ = '_expression',
 
     def _evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:
@@ -195,12 +195,12 @@ class DotExpression(Expression):
         return to_check
 
 
-class SubscriptableExpression(Expression):
+class SubscriptableExpression(CompoundExpression):
     __slots__ = '_expression',
 
     def _evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:
@@ -209,12 +209,12 @@ class SubscriptableExpression(Expression):
         return operand[index]._evaluate(key=key, my=my, target=target)
 
 
-class AttributeExpression(Expression):
+class AttributeExpression(CompoundExpression):
     __slots__ = '_expression',
 
     def _evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ) -> Any:
@@ -271,14 +271,14 @@ class AttributeExpression(Expression):
         return result
 
 
-class UnaryExpression(Expression):
+class UnaryExpression(CompoundExpression):
     __slots__ = '_expression',
 
     operator_map = {"-": None, "!": not_operator}
 
     def _evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ):
@@ -286,7 +286,7 @@ class UnaryExpression(Expression):
         return self.operator_map[self._expression[0]](operand)
 
 
-class ArithmeticExpression(Expression):
+class ArithmeticExpression(CompoundExpression):
     __slots__ = '_expression',
 
     operator_map = {
@@ -329,7 +329,7 @@ class ArithmeticExpression(Expression):
 
     def _evaluate(
         self,
-        key: Optional[Iterable[Union[str, Expression]]] = None,
+        key: Optional[Iterable[Union[str, CompoundExpression]]] = None,
         my: "Optional[ClassAd]" = None,
         target: "Optional[ClassAd]" = None,
     ):

--- a/classad/_functions.py
+++ b/classad/_functions.py
@@ -37,7 +37,7 @@ import random as py_random
 from typing import TypeVar, List, Union, overload, Optional, Any
 
 from classad._grammar import parse
-from classad._base_expression import CompoundExpression
+from classad._base_expression import Expression
 from classad._primitives import (
     Undefined,
     Error,
@@ -59,12 +59,12 @@ def eval(expression: Any) -> literal_type:
     result of evaluating the contents of the string as a :py:class:`~.ClassAd`
     expression.
     """
-    if isinstance(expression, CompoundExpression):
+    if isinstance(expression, Expression):
         return expression
     return parse(expression)
 
 
-def unparse(attribute: CompoundExpression) -> str:
+def unparse(attribute: Expression) -> str:
     """
     This function looks up the value of the provided :py:attr:`attribute` and
     returns the unparsed version as a :py:class:`str`. The attribute's value is

--- a/classad/_functions.py
+++ b/classad/_functions.py
@@ -37,7 +37,7 @@ import random as py_random
 from typing import TypeVar, List, Union, overload, Optional, Any
 
 from classad._grammar import parse
-from classad._base_expression import Expression
+from classad._base_expression import CompoundExpression
 from classad._primitives import (
     Undefined,
     Error,
@@ -59,12 +59,12 @@ def eval(expression: Any) -> literal_type:
     result of evaluating the contents of the string as a :py:class:`~.ClassAd`
     expression.
     """
-    if isinstance(expression, Expression):
+    if isinstance(expression, CompoundExpression):
         return expression
     return parse(expression)
 
 
-def unparse(attribute: Expression) -> str:
+def unparse(attribute: CompoundExpression) -> str:
     """
     This function looks up the value of the provided :py:attr:`attribute` and
     returns the unparsed version as a :py:class:`str`. The attribute's value is

--- a/classad/_grammar.py
+++ b/classad/_grammar.py
@@ -1,6 +1,6 @@
 import pyparsing as pp
 
-from classad._base_expression import Expression
+from classad._base_expression import CompoundExpression
 from classad._expression import (
     ClassAd,
     AttributeExpression,
@@ -250,7 +250,7 @@ expression << pp.Group(
             arithmetic_expression,
         )
     )
-).setParseAction(lambda s, l, t: Expression.from_grammar(t[0])).setName("expression")
+).setParseAction(lambda s, l, t: CompoundExpression.from_grammar(t[0])).setName("expression")
 
 
 def parse(content: str):

--- a/classad/_grammar.py
+++ b/classad/_grammar.py
@@ -250,7 +250,9 @@ expression << pp.Group(
             arithmetic_expression,
         )
     )
-).setParseAction(lambda s, l, t: CompoundExpression.from_grammar(t[0])).setName("expression")
+).setParseAction(lambda s, l, t: CompoundExpression.from_grammar(t[0])).setName(
+    "expression"
+)
 
 
 def parse(content: str):

--- a/classad/_primitives.py
+++ b/classad/_primitives.py
@@ -10,6 +10,7 @@ class Undefined(PrimitiveExpression):
     """
     The keyword ``UNDEFINED`` (case insensitive) represents the ``UNDEFINED`` value.
     """
+
     __slots__ = ()
 
     def __bool__(self):
@@ -67,6 +68,7 @@ class Error(PrimitiveExpression):
     """
     The keyword ``ERROR`` (case insensitive) represents the ``ERROR`` value.
     """
+
     __slots__ = ()
 
     def __bool__(self):
@@ -314,7 +316,7 @@ class HTCFloat(float, PrimitiveExpression):
 
 
 class HTCBool(PrimitiveExpression):
-    __slots__ = '_value',
+    __slots__ = ("_value",)
 
     def __init__(self, x):
         super().__init__()

--- a/classad/_primitives.py
+++ b/classad/_primitives.py
@@ -10,6 +10,7 @@ class Undefined(PrimitiveExpression):
     """
     The keyword ``UNDEFINED`` (case insensitive) represents the ``UNDEFINED`` value.
     """
+    __slots__ = ()
 
     def __bool__(self):
         raise TypeError
@@ -66,6 +67,7 @@ class Error(PrimitiveExpression):
     """
     The keyword ``ERROR`` (case insensitive) represents the ``ERROR`` value.
     """
+    __slots__ = ()
 
     def __bool__(self):
         raise TypeError
@@ -113,6 +115,8 @@ class Error(PrimitiveExpression):
 
 
 class HTCInt(int, PrimitiveExpression):
+    __slots__ = ()
+
     def __add__(self, other):
         if isinstance(other, int):
             return HTCInt(super().__add__(other))
@@ -219,6 +223,8 @@ class HTCInt(int, PrimitiveExpression):
 
 
 class HTCList(tuple, PrimitiveExpression):
+    __slots__ = ()
+
     def __htc_not__(self) -> "Union[HTCBool, Undefined, Error]":
         return Error()
 
@@ -227,6 +233,8 @@ class HTCList(tuple, PrimitiveExpression):
 
 
 class HTCStr(str, PrimitiveExpression):
+    __slots__ = ()
+
     def __htc_eq__(
         self, other: PrimitiveExpression
     ) -> Union[PrimitiveExpression, Undefined, Error]:
@@ -260,6 +268,8 @@ class HTCStr(str, PrimitiveExpression):
 
 
 class HTCFloat(float, PrimitiveExpression):
+    __slots__ = ()
+
     def __mul__(self, other):
         if isinstance(other, (int, float)):
             return HTCFloat(super().__mul__(other))
@@ -304,6 +314,8 @@ class HTCFloat(float, PrimitiveExpression):
 
 
 class HTCBool(PrimitiveExpression):
+    __slots__ = '_value',
+
     def __init__(self, x):
         super().__init__()
         self._value = True if x != 0 else False


### PR DESCRIPTION
This PR straightens the implementation of expressions. Changes includes:

* [x] a common base type ``Expression`` with empty ``__slots__``,
* [x] the ``PrimitiveExpression`` directly inherits from the new ``Expression``,
* [x] renamed the original ``Expression`` to ``CompoundExpression``,
* [x] added ``__slots__`` to all classes.

```
# old
Expression +--> PrimitiveExpression ---> {HTCBool, HTCStr, ...}
           \-->  {NamedExpression, FunctionExpression, ...}
# new
Expression +--> PrimitiveExpression ---> {HTCBool, HTCStr, ...}
           \--> CompundExpression   ---> {NamedExpression, FunctionExpression, ...}
```