### PR TITLE
Quantize now also gives correct result for empty list

### DIFF
--- a/classad/_functions.py
+++ b/classad/_functions.py
@@ -414,7 +414,10 @@ def quantize(a, b):
                     return element
             except TypeError:
                 return Error()
-        return quantize(a, element)
+        try:
+            return quantize(a, element)
+        except UnboundLocalError:
+            return Error()
     else:
         try:
             quotient = HTCFloat(a / b)

--- a/classad_tests/functions/test_quantize.py
+++ b/classad_tests/functions/test_quantize.py
@@ -46,3 +46,4 @@ class TestQuantize:
         assert isinstance(
             quantize(HTCInt(3), HTCList([HTCInt(1), HTCInt(2), HTCStr("A")])), Error
         )
+        assert quantize(HTCInt(3), HTCList([])) == Error()


### PR DESCRIPTION
Quantize couldn't work with empty lists until now. This is fixed now. This PR also includes a unit test for empty lists.