### PR TITLE
Evaluate expression with classad

### DIFF
--- a/classad/_expression.py
+++ b/classad/_expression.py
@@ -232,18 +232,21 @@ class AttributeExpression(CompoundExpression):
             the_key = scope_up(self._expression[1])
             expression = self._expression[1][-1]
         elif self._expression[0] == "target":
-            if my is None or target is None:
+            if target is None:
                 return Undefined()
             selected_classad = target
             expression = self._expression[1]
         elif self._expression[0] == "my":
-            if my is None or target is None:
+            if my is None:
                 return Undefined()
-            expression = self._expression
+            expression = self._expression[1]
         else:
             expression = self._expression
         try:
-            context = find_scope(the_key, classad=selected_classad)
+            if the_key is None and selected_classad is not None:
+                context = selected_classad
+            else:
+                context = find_scope(the_key, classad=selected_classad)
         except TypeError:
             return Error()
         while isinstance(value, Undefined):

--- a/classad_tests/test_evaluation.py
+++ b/classad_tests/test_evaluation.py
@@ -1,0 +1,8 @@
+from classad import parse
+from classad._primitives import HTCInt
+
+
+def test_simple():
+    first_part = parse("my.a + 2")
+    my_classad = parse("a = 4")
+    assert first_part.evaluate(my=my_classad) == HTCInt(6)

--- a/docs/source/change/18.expression_evaluation.yaml
+++ b/docs/source/change/18.expression_evaluation.yaml
@@ -1,0 +1,8 @@
+category: added
+summary: "Evaluation of expression in context of classad"
+description: |
+  The project can now evaluate an expression in the context of a classads.
+issues:
+  - 17
+pull requests:
+  - 18


### PR DESCRIPTION
So far classads could be evaluated with a target classad. But we did not include evaluating an expression (that is not a classad itself) in the context of a classad. This has been added with this PR.

Closes #17.