### PR TITLE
Support of negation in unary operation

### DIFF
--- a/classad/_expression.py
+++ b/classad/_expression.py
@@ -4,7 +4,7 @@ from collections import MutableMapping
 import pyparsing as pp
 from typing import Iterable, List, Iterator, Optional, Union, Tuple
 
-from classad._operator import eq_operator, ne_operator, not_operator
+from classad._operator import eq_operator, ne_operator, not_operator, neg_operator
 from classad._primitives import Error, Undefined, HTCBool
 from ._base_expression import CompoundExpression, Expression
 from . import _functions
@@ -297,7 +297,7 @@ class AttributeExpression(CompoundExpression):
 class UnaryExpression(CompoundExpression):
     __slots__ = ()
 
-    operator_map = {"-": None, "!": not_operator}
+    operator_map = {"-": neg_operator, "!": not_operator}
 
     def _evaluate(
         self,

--- a/classad/_operator.py
+++ b/classad/_operator.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from classad._base_expression import PrimitiveExpression
-from classad._primitives import HTCBool, Undefined, Error
+from classad._primitives import HTCBool, Undefined, Error, HTCInt, HTCFloat
 
 
 def eq_operator(
@@ -58,3 +58,18 @@ def not_operator(a: PrimitiveExpression) -> Union[HTCBool, Undefined, Error]:
         parse("!False").evaluate()  # result: HTCBool(True)
     """
     return a.__htc_not__()
+
+
+def neg_operator(a: PrimitiveExpression) -> Union[HTCInt, HTCFloat, Undefined, Error]:
+    """
+    Negation operator as defined by classad specification.
+
+    .. code:: python3
+        parse("-1").evaluate()  # result: HTCInt(-1)
+    """
+    result = -1 * a
+    if isinstance(result, int):
+        return HTCInt(result)
+    elif isinstance(result, float):
+        return HTCFloat(result)
+    return Error()

--- a/classad_tests/test_grammar.py
+++ b/classad_tests/test_grammar.py
@@ -219,6 +219,7 @@ class TestGrammar(object):
         assert parse("-1.0").evaluate() == HTCFloat(-1.0)
         assert parse("-'test'").evaluate() == Error()
         assert parse("-1 * 2.0").evaluate() == HTCFloat(-2)
+        assert parse("-Error").evaluate() == Error()
 
     def test_ternary(self):
         assert parse("true?10:undefined").evaluate() == HTCInt(10)

--- a/classad_tests/test_grammar.py
+++ b/classad_tests/test_grammar.py
@@ -214,6 +214,12 @@ class TestGrammar(object):
         assert parse("!'test'").evaluate() == Error()
         assert not parse("[a=True;b=!a]").evaluate("b")
 
+    def test_negation(self):
+        assert parse("-1").evaluate() == HTCInt(-1)
+        assert parse("-1.0").evaluate() == HTCFloat(-1.0)
+        assert parse("-'test'").evaluate() == Error()
+        assert parse("-1 * 2.0").evaluate() == HTCFloat(-2)
+
     def test_ternary(self):
         assert parse("true?10:undefined").evaluate() == HTCInt(10)
         assert parse('false?error:"foo"').evaluate() == HTCStr("foo")

--- a/docs/source/change/21.unary_operation.yaml
+++ b/docs/source/change/21.unary_operation.yaml
@@ -1,0 +1,6 @@
+category: added
+summary: "Negation for unary operation"
+description: |
+  Classads now also support negation in unary operations.
+pull requests:
+- 21

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,9 +1,17 @@
-.. Created by log.py at 2020-02-17, command
+.. Created by log.py at 2020-02-21, command
    '/Users/eileenwork/development/work/classad/venv/lib/python3.7/site-packages/change/__main__.py log docs/source/change compile --output docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 #########
 ChangeLog
 #########
+
+Upcoming
+========
+
+Version [Unreleased] - 2020-02-21
++++++++++++++++++++++++++++++++++
+
+* **[Added]** Negation for unary operation
 
 0.3 Series
 ==========


### PR DESCRIPTION
Currently the negation of numbers was not possible for classads, this is added now.

This PR includes:

* [x] implementation,
* [x] unit tests,
* [x] change fragment.