### PR TITLE
Update version requirement for pyparsing to >= 2.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description-file = "README.rst"
 keywords = "htcondor classad python"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires = [
-    "pyparsing"
+    "pyparsing >= 2.4.1"
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description-file = "README.rst"
 keywords = "htcondor classad python"
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires = [
-    "pyparsing >= 2.4.1"
+    "pyparsing ~= 2.4.2"
 ]
 
 [tool.flit.metadata.requires-extra]


### PR DESCRIPTION
this PR introduces a minimum version requirement of 2.4.1 for pyparsing to account for required functionalities in the pyparsing package (see issue #23 ).

Solves #23 