### PR TITLE
Release of version 0.4.1

### DIFF
--- a/classad/__init__.py
+++ b/classad/__init__.py
@@ -105,4 +105,4 @@ __all__ = [
     "userMap",
     "parse",
 ]
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/classad/_grammar.py
+++ b/classad/_grammar.py
@@ -214,12 +214,12 @@ suffix_expression << pp.MatchFirst(
 ).setName("suffix_expression")
 
 
-def binary_parse_action(s, l, t):
-    return ArithmeticExpression.from_grammar(t[0])
+def binary_parse_action(orig_parse_string, location, tokens):
+    return ArithmeticExpression.from_grammar(tokens[0])
 
 
-def unary_parse_action(s, l, t):
-    return UnaryExpression.from_grammar(t[0])
+def unary_parse_action(orig_parse_string, location, tokens):
+    return UnaryExpression.from_grammar(tokens[0])
 
 
 # unary operators: + - ~ !


### PR DESCRIPTION
This PR bumps the version to release version 0.4.1. This version includes the change that the minimal version of pyparsing was defined to be 2.4.2, excluding versions above 3.x.